### PR TITLE
Add `upload` command

### DIFF
--- a/sources/commands/Makefile.am
+++ b/sources/commands/Makefile.am
@@ -54,7 +54,8 @@ SUBSRC = \
 	TCmdPadZoom.cc\
 	TCmdHcol.cc\
 	TCmdProcessorDescription.cc \
-	TCmdMergeFile.cc
+	TCmdMergeFile.cc\
+	TCmdUpload.cc
 
 
 SUBOBJ = $(SUBSRC:.cc=.o)

--- a/sources/commands/TCmdUpload.cc
+++ b/sources/commands/TCmdUpload.cc
@@ -1,0 +1,102 @@
+/**
+ * @file   TCmdUpload.cc
+ * @brief  Upload image file to GitLab via API
+ *
+ * @date   Created       : 2020-04-30 22:13:55 JST
+ *         Last Modified :
+ * @author Shoichiro Masuoka <masuoka@cns.s.u-tokyo.ac.jp>
+ *
+ *    (C) 2020 Shoichiro Masuoka
+ */
+
+#include "TCmdUpload.h"
+#include "TCmdSave.h"
+
+#include <TSystem.h>
+#include <TPRegexp.h>
+#include <TObjArray.h>
+#include <TObject.h>
+#include <TObjString.h>
+#include <TString.h>
+
+using art::TCmdUpload;
+
+ClassImp(TCmdUpload)
+
+TCmdUpload::TCmdUpload()
+//: fJSONResult("")
+{
+   SetName("upload");
+   SetTitle("Upload image file to GitLab via API");
+}
+
+TCmdUpload::~TCmdUpload()
+{
+}
+
+
+Long_t TCmdUpload::Cmd(vector<TString>)
+{
+   return Run();
+}
+
+Long_t TCmdUpload::Run()
+{
+   const TString &filename = TCmdSave::Instance()->GetPrintFileName();
+   if (filename.IsNull()) {
+      Error("Run","There is no file to be uploaded.");
+      return 1;
+   }
+   if (GetUploadURL() != NULL && GetPrivateTokenFile() != NULL) {
+      Info("Run",TString::Format("upload image file: %s to %s",filename.Data(),GetUploadURL()));
+      UploadFile(filename);
+   } else {
+      Error("Run","Upload URL and/or private access token file are not specified");
+      return 1;
+   }
+   return 1;
+}
+
+void TCmdUpload::UploadFile(const TString &fileName)
+{
+   TString token = gSystem->GetFromPipe(TString::Format("cat %s",GetPrivateTokenFile()));
+   if (token.IsNull()) {
+      Error("UploadFile","invalid token file");
+      return;
+   }
+   TString sendAPI = TString::Format("curl --request POST --header 'PRIVATE-TOKEN: %s' --form 'file=@%s' %s", token.Data(),fileName.Data(),GetUploadURL());
+   printf("%s\n",sendAPI.Data());
+   const TString json = gSystem->GetFromPipe(sendAPI);
+   PrintMarkdown(json);
+}
+
+void TCmdUpload::PrintMarkdown(const TString json)
+{
+//   const TString json = GetJSONResult();
+   if (json.IsNull()) {
+      Error("PrintMarkdown","failed to upload");
+   } else {
+      TObjArray *resultList = TPRegexp("\"markdown\":\"(.*)\"").MatchS(json);
+      TObject *resultPtr = (TObjString*)resultList->At(1);
+      if (resultPtr == NULL) {
+         Error("PrintMarkdown", TString::Format("failed to upload: JSON parse error\n %s",json.Data()));
+         printf("suggestion-> 401: invalid access token, 404: invalid URL\n");
+         return;
+      } else {
+         TString result = ((TObjString*)resultList->At(1))->GetString();
+         printf("Upload completed. Markdown: %s\n",result.Data());
+         CopyToClipBoard(result);
+      }
+   }
+}
+
+void TCmdUpload::CopyToClipBoard(const TString &content)
+{
+   TString command = GetClipBoardAccessCommand();
+   if (command.IsNull()) {
+      Info("CopyToClipBoard","clip board command is not specified");
+      return;
+   } else {
+      gSystem->Exec(TString::Format("echo '%s' | %s",content.Data(),GetClipBoardAccessCommand()));
+   }
+}

--- a/sources/commands/TCmdUpload.h
+++ b/sources/commands/TCmdUpload.h
@@ -36,6 +36,7 @@ Upload image which is saved immediately before using TCmdSave (save command) to 
    cmdupload->SetPrivateTokenFile(".gitlab_api_token");
    // --- (option) command for copying to clipboard ---
    cmdupload->SetClipBoardAccessCommand("xsel -bi");
+   cmdupload->UseTmux(kTRUE); // if you use tmux & want to copy to clipboard, please add
    // --- end option ---
    cf->Register(cmdupload);
 
@@ -73,13 +74,9 @@ public:
    virtual Long_t Run();
 
    virtual void UploadFile(const TString&);
-   virtual void PrintMarkdown(const TString);
+   virtual void PrintMarkdown(const TString&);
    virtual void CopyToClipBoard(const TString&);
    
-
-   // virtual void SetJSONResult(const TString json) { fJSONResult = json; }
-   // virtual TString GetJSONResult() const { return fJSONResult; }
-
    virtual void SetClipBoardAccessCommand(const TString command) { fClipBoardAccessCommand = command; }
    virtual const char* GetClipBoardAccessCommand() { return fClipBoardAccessCommand.Data(); }
 
@@ -89,22 +86,18 @@ public:
    virtual void SetPrivateTokenFile(const TString token) { fPrivateTokenFile = token; }
    virtual const char* GetPrivateTokenFile() { return fPrivateTokenFile.Data(); }
 
-   // virtual void SetCopiedKeyName(const TString key) { fCopiedKeyName = key; }
-   // virtual const char* GetCopiedKeyName() { return fCopiedKeyName.Data(); }
-
-   // virtual void SetCopyToClipBoard(Bool_t copyToClipBoard = kFALSE) { fClopToClipBoard = copyToClipBoard; }
-   // virtual Bool_t CopyToClipBoard() const { return fCopyToClipBoard; }
-   
+   virtual void UseTmux(const Bool_t tmux=kFALSE) { fUseTmux = tmux; }
+   virtual const Bool_t GetUseTmux() { return fUseTmux; }
+  
 protected:
 
 private:
 
-//   Bool_t fCopyToClipBoard;
-   TString fPrivateTokenFile;
-   TString fUploadURL;
-//   TString fJSONResult;
+   TString fPrivateTokenFile; // set gitlab access token file.
+   TString fUploadURL; // set upload URL.
    TString fClipBoardAccessCommand; // execute clip board command. Ex. 'xclip -selection c', 'xsel -bi'
-
+   Bool_t fUseTmux; // if you use tmux & want to copy to clipboard, switch to kTRUE. (default: kFALSE)
+   
    ClassDef(TCmdUpload,1) // Upload image file to GitLab via API
 };
 

--- a/sources/commands/TCmdUpload.h
+++ b/sources/commands/TCmdUpload.h
@@ -1,0 +1,111 @@
+/**
+ * @file   TCmdUpload.h
+ * @brief  Upload image file to GitLab via API
+ *
+ * @date   Created       : 2020-04-30 22:14:36 JST
+ *         Last Modified :
+ * @author Shoichiro Masuoka <masuoka@cns.s.u-tokyo.ac.jp>
+ *
+ *    (C) 2020 Shoichiro Masuoka
+ */
+/*
+
+Upload image which is saved immediately before using TCmdSave (save command) to GitLab via API. 
+
+- Settings
+
+1. sign in to your GitLab account and open the user settings.
+2. choose "Access Tokens" and create token with API scopes.
+3. copy token and paste to a file (ex. .gitlab_api_token). Strongly recommend to add .gitignore this file if you put it into the git control directory.
+4. remember your project ID to put image.
+5. (option) if you want to copy to clipboard for returned markdown URL, install the clipboard access app. (ex. xsel, xclip, etc...)
+6. add 'artemislogon.C' like,
+
+   TCatCmdFactory *cf = TCatCmdFactory::Instance();
+   // ...... (add the other commands) ......
+   art::TCmdSave *cmdsave = art::TCmdSave::Instance();
+   cmdsave->SetDefaultDirectory("figs") // Do NOT include ~ charactor when you use upload command. If you specify the home directory, please write by absolute path.
+   cmdsave->SetAddDateDir(kTRUE);
+   cmdsave->SetAutoName(kTRUE);
+   cmdsave->AddFormat("png",1); // specify '1' at the 2nd parameter
+   // ...... (Add format)
+   cf->Register(cmdsave);
+   
+   art::TCmdUpload *cmdupload = new art::TCmdUpload();
+   cmdupload->SetUploadURL("(GitLab host)/api/v4/projects/(project ID)/uploads");
+   cmdupload->SetPrivateTokenFile(".gitlab_api_token");
+   // --- (option) command for copying to clipboard ---
+   cmdupload->SetClipBoardAccessCommand("xsel -bi");
+   // --- end option ---
+   cf->Register(cmdupload);
+
+- Usage
+
+1. Draw histograms which you want to upload
+2. type "save" command
+   artemis [] save
+3. type "upload" command after you save
+   artemis [] upload
+4. markdown will be printed (and copied to clipboard if you specify clipboard command)
+5. paste it at issues, merge requests, milestones, Wiki, etc... on your project
+
+
+ */
+#ifndef INCLUDE_GUARD_UUID_91997D95_8F39_429D_8EB5_3A664BAF8424
+#define INCLUDE_GUARD_UUID_91997D95_8F39_429D_8EB5_3A664BAF8424
+
+#include "TCatCmd.h"
+
+#include <TString.h>
+#include <vector>
+
+namespace art {
+   class TCmdUpload;
+}
+
+class art::TCmdUpload : public TCatCmd {
+public:
+   TCmdUpload();
+   virtual ~TCmdUpload();
+
+
+   virtual Long_t Cmd(vector<TString>);
+   virtual Long_t Run();
+
+   virtual void UploadFile(const TString&);
+   virtual void PrintMarkdown(const TString);
+   virtual void CopyToClipBoard(const TString&);
+   
+
+   // virtual void SetJSONResult(const TString json) { fJSONResult = json; }
+   // virtual TString GetJSONResult() const { return fJSONResult; }
+
+   virtual void SetClipBoardAccessCommand(const TString command) { fClipBoardAccessCommand = command; }
+   virtual const char* GetClipBoardAccessCommand() { return fClipBoardAccessCommand.Data(); }
+
+   virtual void SetUploadURL(const TString url) { fUploadURL = url; }
+   virtual const char* GetUploadURL() { return fUploadURL.Data(); }
+
+   virtual void SetPrivateTokenFile(const TString token) { fPrivateTokenFile = token; }
+   virtual const char* GetPrivateTokenFile() { return fPrivateTokenFile.Data(); }
+
+   // virtual void SetCopiedKeyName(const TString key) { fCopiedKeyName = key; }
+   // virtual const char* GetCopiedKeyName() { return fCopiedKeyName.Data(); }
+
+   // virtual void SetCopyToClipBoard(Bool_t copyToClipBoard = kFALSE) { fClopToClipBoard = copyToClipBoard; }
+   // virtual Bool_t CopyToClipBoard() const { return fCopyToClipBoard; }
+   
+protected:
+
+private:
+
+//   Bool_t fCopyToClipBoard;
+   TString fPrivateTokenFile;
+   TString fUploadURL;
+//   TString fJSONResult;
+   TString fClipBoardAccessCommand; // execute clip board command. Ex. 'xclip -selection c', 'xsel -bi'
+
+   ClassDef(TCmdUpload,1) // Upload image file to GitLab via API
+};
+
+#endif // INCLUDE_GUARD_UUID_91997D95_8F39_429D_8EB5_3A664BAF8424

--- a/sources/commands/catcmd_linkdef.h
+++ b/sources/commands/catcmd_linkdef.h
@@ -61,5 +61,6 @@
 #pragma link C++ class TCatCmdFactory+;
 #pragma link C++ class art::TCmdGroup+;
 #pragma link C++ class art::TCmdProcessorDescription+;
+#pragma link C++ class art::TCmdUpload;
 
 #endif /* __CINT__ */


### PR DESCRIPTION
A new ARTEMIS command, 'upload' is created.
Upload image to GitLab project attachment via the API.

# Usage

1. sign in to your GitLab account and open the user settings.
2. choose "Access Tokens" and create token with API scopes.
3. copy token and paste to a file (ex. .gitlab_api_token). 
4. (option) if you want to copy to clipboard for returned markdown URL, install the clipboard access app. (ex. xsel,xclip, etc...)
5. add 'artemislogon.C' like,

```cc
   TCatCmdFactory *cf = TCatCmdFactory::Instance();
   // ...... (add the other commands) ......
   art::TCmdSave *cmdsave = art::TCmdSave::Instance();
   cmdsave->SetDefaultDirectory("figs") // Do NOT include ~ charactor when you use upload command. If you specify the home directory, please write by absolute path.
   cmdsave->SetAddDateDir(kTRUE);
   cmdsave->SetAutoName(kTRUE);
   cmdsave->AddFormat("png",1); // specify '1' at the 2nd parameter
   // ...... (Add format)
   cf->Register(cmdsave);

   art::TCmdUpload *cmdupload = new art::TCmdUpload();
   cmdupload->SetUploadURL("(GitLab host)/api/v4/projects/(project ID)/uploads");
   cmdupload->SetPrivateTokenFile(".gitlab_api_token");
   // --- (option) command for copying to clipboard ---
   cmdupload->SetClipBoardAccessCommand("xsel -bi");
   cmdupload->UseTmux(kTRUE); // if you use tmux & want to copy to clipboard, please add
   // --- end option ---
   cf->Register(cmdupload);
```

The upload file is select automatically before use `TCmdSave` (`save` command) like:

```
artemis [] ht 1
artemis [] save
figs/20200501/1588344333.png
Info in <TCanvas::Print>: file figs/20200501/1588344333.png has been created
figs/20200501/1588344333.root
Info in <TCanvas::SaveAs>: ROOT file figs/20200501/1588344333.root has been created
figs/20200501/1588344333.pdf
Info in <TCanvas::Print>: pdf file figs/20200501/1588344333.pdf has been created
artemis [] upload
Info in <art::TCmdUpload::Run>: upload image file: figs/20200501/1588344333.pngto https://(GitLab URL)/api/v4/projects/(Project ID)/uploads
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 24042  170   170  100 23872    553  77718 --:--:-- --:--:-- --:--:--  143k
Upload completed. Markdown:
![1588344333](/uploads/xxxxxxxxxx/1588344333.png)
```

After run this command, copy markdown and paste to the issue where you specified  project, uploaded image will be shown.

`curl` is required when an image file is uploaded.
In addition, copying clipboard feature is also implemented. If you specify X Clipboard access command (Ex. `xsel -bi`, `xclip -sel c`), put to the clipboard markdown automatically.
When use VNC, cannot to access to lcoalhost's X server (= cannot share clipboards). To avoid this situation, get the localhost's X server via the 'tmux  showenv DISPLAY' and set with `env` command.