### PR TITLE
removed FORCE option of CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(artemis)
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 
 # Default installation dir
-set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/install/ CACHE PATH "install dir" FORCE)
+set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/install/ CACHE PATH "install dir")
 
 # Build options
 option(BUILD_GET "Build and install libraries using GET" OFF)

--- a/artemis-config.cmake.in
+++ b/artemis-config.cmake.in
@@ -3,6 +3,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/artemisTargets.cmake")
 
 # Definition of variables
 set(ARTEMIS_BUILD_GET "@BUILD_GET@")
-set(ARTEMIS_YAML_CPP_LIB_DIR "@yaml_cpp_LIBDIR@")
+set(ARTEMIS_YAML_CPP_LIB_DIR "@yaml_cpp_INCLUDEDIR@")
 set(ARTEMIS_GET_INCLUDE_DIR "@GET_INCLUDE_DIR@")
 set(ARTEMIS_GET_LIB_DIR "@GET_LIB_DIR@")


### PR DESCRIPTION
* I accidentally committed the CMakeLists.txt file with FORCE option on CMAKE_INSTALL_PREFIX so it was ignoring the option given by users. Removed the FORCE option.
*  yaml_cpp_LIBDIR in artemis-config.cmake is replaced with yaml_cpp_INCLUDEDIR