### PR TITLE
Issue47

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 
 # Default installation dir
 set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/install/ CACHE PATH "install dir")
+set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-as-needed")
 
 # Build options
 option(BUILD_GET "Build and install libraries using GET" OFF)
@@ -19,7 +20,7 @@ if(BUILD_GET)
 endif()
 
 #---Locate the ROOT package and defines a number of variables (e.g. ROOT_INCLUDE_DIRS)
-find_package(ROOT REQUIRED COMPONENTS RIO Net Physics Geom Minuit2 Gui)
+find_package(ROOT REQUIRED COMPONENTS RIO Net Physics Geom Minuit Minuit2 Gui)
 find_package(MPI)
 if(MPI_CXX_FOUND)
     add_compile_definitions(USE_MPI)

--- a/sources/loop/decoder/TModuleDecoderV1190.cc
+++ b/sources/loop/decoder/TModuleDecoderV1190.cc
@@ -20,25 +20,28 @@ using art::TRawTimingWithEdge;
 typedef TRawTimingWithEdge V1190Raw_t;
 
 TModuleDecoderV1190::TModuleDecoderV1190()
-   : TModuleDecoder(kID,V1190Raw_t::Class()) {
+    : TModuleDecoder(kID, V1190Raw_t::Class())
+{
    fHitData = new TObjArray;
 }
 
 TModuleDecoderV1190::TModuleDecoderV1190(Int_t id)
-   : TModuleDecoder(id,V1190Raw_t::Class()) {
+    : TModuleDecoder(id, V1190Raw_t::Class())
+{
    fHitData = new TObjArray;
 }
 
 TModuleDecoderV1190::~TModuleDecoderV1190()
 {
-   if (fHitData) delete fHitData;
+   if (fHitData)
+      delete fHitData;
    fHitData = NULL;
 }
 
-Int_t TModuleDecoderV1190::Decode(char* buf, const int &size, TObjArray *seg)
+Int_t TModuleDecoderV1190::Decode(char *buf, const int &size, TObjArray *seg)
 {
-   UInt_t *evtdata = (UInt_t*) buf;
-   UInt_t evtsize = size/sizeof(UInt_t);
+   UInt_t *evtdata = (UInt_t *)buf;
+   UInt_t evtsize = size / sizeof(UInt_t);
    Int_t ih, igeo, ich;
    Int_t ghf, thf, bncid, evtid, edge, idx;
    V1190Raw_t *data;
@@ -48,55 +51,68 @@ Int_t TModuleDecoderV1190::Decode(char* buf, const int &size, TObjArray *seg)
    // clear old hits
    fHitData->Clear();
 
-   for (Int_t i=0; i<evtsize; ++i) {
-      ih = evtdata[i]&kHeaderMask;
-      if ((evtdata[i]&kHeaderMask) == kGlobalTrailer) {
+   for (Int_t i = 0; i < evtsize; ++i)
+   {
+      ih = evtdata[i] & kHeaderMask;
+      if ((evtdata[i] & kHeaderMask) == kGlobalTrailer)
+      {
          ghf = 0;
-      } else  {
-         switch (ih) {
+      }
+      else
+      {
+         switch (ih)
+         {
          case kGlobalHeader:
             ghf = 1;
-            igeo = (evtdata[i]&kMaskGeometry)>>kShiftGeometry;
+            igeo = (evtdata[i] & kMaskGeometry) >> kShiftGeometry;
             break;
          case kTDCHeader:
-            if (ghf!=1) continue;
+            if (ghf != 1)
+               continue;
             thf = 1;
-            bncid = (evtdata[i]&kMaskBunchID)>>kShiftBunchID;
-            evtid = (evtdata[i]&kMaskEventCounter)>>kShiftEventCounter;
+            bncid = (evtdata[i] & kMaskBunchID) >> kShiftBunchID;
+            evtid = (evtdata[i] & kMaskEventCounter) >> kShiftEventCounter;
             break;
          case kTDCMeasurement:
-            if (ghf!=1) continue;
-            ich = (evtdata[i]&kMaskChannel) >> kShiftChannel;
-            edge = (evtdata[i]&kMaskEdgeType) >> kShiftEdgeType;
+            if (ghf != 1)
+               continue;
+            ich = (evtdata[i] & kMaskChannel) >> kShiftChannel;
+            edge = (evtdata[i] & kMaskEdgeType) >> kShiftEdgeType;
             idx = igeo * 128 + ich;
-            if (idx < 0) {
-               printf("[%03d] igeo = %d, ich = %d\n",i,igeo,ich);
+            if (idx < 0)
+            {
+               printf("[%03d] igeo = %d, ich = %d\n", i, igeo, ich);
             }
-            measure = (evtdata[i]&kMaskMeasure) >> kShiftMeasure;
-            
+            measure = (evtdata[i] & kMaskMeasure) >> kShiftMeasure;
+
             // check if the data object exists.
-            if (fHitData->GetEntriesFast() <= idx || !fHitData->At(idx)) {
+            if (fHitData->GetEntriesFast() <= idx || !fHitData->At(idx))
+            {
                // if no data object is available, create one
-               V1190Raw_t *obj = static_cast<V1190Raw_t*>(this->New());
-               obj->SetSegInfo(seg->GetUniqueID(),igeo,ich);
-               fHitData->AddAtAndExpand(obj,idx);
+               V1190Raw_t *obj = static_cast<V1190Raw_t *>(this->New());
+               obj->SetSegInfo(seg->GetUniqueID(), igeo, ich);
+               fHitData->AddAtAndExpand(obj, idx);
                seg->Add(obj);
             }
-            
-            data = static_cast<V1190Raw_t*>(fHitData->At(idx));
-            
+
+            data = static_cast<V1190Raw_t *>(fHitData->At(idx));
+
             data->Set(measure);
             data->SetEdge(!edge); // definition of edge is opposite to that in TRawTimingWithEdge
-            fHitData->AddAt(NULL,idx);
-            
+            fHitData->AddAt(NULL, idx);
+
             break;
          case kTDCTrailer:
             thf = 0;
             break;
          case kTDCError:
-            ghf = thf = 0;
-            if (kWarning>=fVerboseLevel) {
-               Warning("Decode",Form("V1190 [TDC Error    ] : 0x%08x at %d", evtdata[i],i));
+            // Set header flags to 0 (stop reading the segment)
+            // if TDC error flags are fatal
+            if (TdcErrorCheck(evtdata[i]))
+               ghf = thf = 0;
+            if (kWarning >= fVerboseLevel)
+            {
+               Warning("Decode", Form("V1190 [TDC Error    ] : 0x%08x at %d", evtdata[i], i));
             }
             break;
          }

--- a/sources/loop/decoder/TModuleDecoderV1190.h
+++ b/sources/loop/decoder/TModuleDecoderV1190.h
@@ -49,6 +49,7 @@ public:
    static const int kShiftMeasure = 0;
    static const int kShiftEdgeType = 26;
 
+   // bits 1: Skip, 0: Continue
    // Error flags:
    // [0]: Hit lost in group 0 from read-out FIFO overflow.
    // [1]: Hit lost in group 0 from L1 buffer overflow
@@ -78,7 +79,7 @@ protected:
     */
    Bool_t TdcErrorCheck(UInt_t evtdata)
    {
-      if (evtdata && kTDCErrorsSkip)
+      if (evtdata & kTDCErrorsSkip)
          return true;
       else
          return false;

--- a/sources/loop/decoder/TModuleDecoderV1190.h
+++ b/sources/loop/decoder/TModuleDecoderV1190.h
@@ -12,44 +12,78 @@
 #define TMODULEDECODERV1190_H
 #include <TModuleDecoder.h>
 
-namespace art {
+namespace art
+{
    class TModuleDecoderV1190;
 }
 
-class art::TModuleDecoderV1190  : public TModuleDecoder {
+class art::TModuleDecoderV1190 : public TModuleDecoder
+{
 public:
    static const int kID = 24;
 
    TModuleDecoderV1190();         // constructor with default id = kID for compatibility
    TModuleDecoderV1190(Int_t id); // constructor with id
    virtual ~TModuleDecoderV1190();
-   virtual Int_t Decode(char* buffer, const int &size, TObjArray *seg);
+   virtual Int_t Decode(char *buffer, const int &size, TObjArray *seg);
 
-   static const unsigned int kHeaderMask        = 0xf8000000;
-   static const unsigned int kGlobalHeader      = 0x40000000;
-   static const unsigned int kTDCHeader         = 0x08000000;
-   static const unsigned int kTDCMeasurement    = 0x00000000;
-   static const unsigned int kTDCTrailer        = 0x18000000;
-   static const unsigned int kTDCError          = 0x20000000;
-   static const unsigned int kGlobalTrailer     = 0x80000000;
-   static const unsigned int kMaskGeometry      = 0x0000001f;
-   static const unsigned int kMaskEventCounter  = 0x7ffffe0;
-   static const unsigned int kMaskBunchID       = 0x00000fff;
-   static const unsigned int kMaskEventID       = 0x00000fff;
-   static const unsigned int kMaskChannel       = 0x03f80000;
-   static const unsigned int kMaskMeasure       = 0x0007ffff;
-   static const unsigned int kMaskEdgeType      = 0x04000000;
-   static const int kShiftGeometry     = 0;
+   static const unsigned int kHeaderMask = 0xf8000000;
+   static const unsigned int kGlobalHeader = 0x40000000;
+   static const unsigned int kTDCHeader = 0x08000000;
+   static const unsigned int kTDCMeasurement = 0x00000000;
+   static const unsigned int kTDCTrailer = 0x18000000;
+   static const unsigned int kTDCError = 0x20000000;
+   static const unsigned int kGlobalTrailer = 0x80000000;
+   static const unsigned int kMaskGeometry = 0x0000001f;
+   static const unsigned int kMaskEventCounter = 0x7ffffe0;
+   static const unsigned int kMaskBunchID = 0x00000fff;
+   static const unsigned int kMaskEventID = 0x00000fff;
+   static const unsigned int kMaskChannel = 0x03f80000;
+   static const unsigned int kMaskMeasure = 0x0007ffff;
+   static const unsigned int kMaskEdgeType = 0x04000000;
+   static const int kShiftGeometry = 0;
    static const int kShiftEventCounter = 5;
-   static const int kShiftBunchID      = 0;
-   static const int kShiftEventID      = 12;
-   static const int kShiftChannel      = 19;
-   static const int kShiftMeasure      = 0;
-   static const int kShiftEdgeType     = 26;
+   static const int kShiftBunchID = 0;
+   static const int kShiftEventID = 12;
+   static const int kShiftChannel = 19;
+   static const int kShiftMeasure = 0;
+   static const int kShiftEdgeType = 26;
+
+   // Error flags:
+   // [0]: Hit lost in group 0 from read-out FIFO overflow.
+   // [1]: Hit lost in group 0 from L1 buffer overflow
+   // [2]: Hit error have been detected in group 0.
+   // [3]: Hit lost in group 1 from read-out FIFO overflow.
+   // [4]: Hit lost in group 1 from L1 buffer overflow
+   // [5]: Hit error have been detected in group 1.
+   // [6]: Hit data lost in group 2 from read-out FIFO overflow.
+   // [7]: Hit lost in group 2 from L1 buffer overflow
+   // [8]: Hit error have been detected in group 2.
+   // [9]: Hit lost in group 3 from read-out FIFO overflow.
+   // [10]: Hit lost in group 3 from L1 buffer overflow
+   // [11]: Hit error have been detected in group 3.
+   // [12]: Hits rejected because of programmed event size limit
+   // [13]: Event lost (trigger FIFO overflow).
+   // [14]: Internal fatal chip error has been detected
+   static const unsigned int kTDCErrorsSkip = 0b111100100100100;
 
 protected:
    TObjArray *fHitData; // array to temporally store the data for the aggregation
 
-   ClassDef(TModuleDecoderV1190,0); // decoder for module V1190
+   /**
+    * @brief Returns true if the TDC error type is fatal (The segment should be skipped)
+    *
+    * @param evtdata eventdata[i]
+    * @return Bool_t Skip flag
+    */
+   Bool_t TdcErrorCheck(UInt_t evtdata)
+   {
+      if (evtdata && kTDCErrorsSkip)
+         return true;
+      else
+         return false;
+   }
+
+   ClassDef(TModuleDecoderV1190, 0); // decoder for module V1190
 };
 #endif // end of #ifdef TMODULEDECODERV1190_H

--- a/sources/loop/decoder/TModuleDecoderV1290.h
+++ b/sources/loop/decoder/TModuleDecoderV1290.h
@@ -49,6 +49,7 @@ public:
    static const int kShiftMeasure = 0;
    static const int kShiftEdgeType = 26;
 
+   // bits 1: Skip, 0: Continue
    // Error flags:
    // [0]: Hit lost in group 0 from read-out FIFO overflow.
    // [1]: Hit lost in group 0 from L1 buffer overflow
@@ -78,7 +79,7 @@ protected:
     */
    Bool_t TdcErrorCheck(UInt_t evtdata)
    {
-      if (evtdata && kTDCErrorsSkip)
+      if (evtdata & kTDCErrorsSkip)
          return true;
       else
          return false;

--- a/sources/loop/decoder/TModuleDecoderV1290.h
+++ b/sources/loop/decoder/TModuleDecoderV1290.h
@@ -12,44 +12,78 @@
 #define TMODULEDECODERV1290_H
 #include <TModuleDecoder.h>
 
-namespace art {
+namespace art
+{
    class TModuleDecoderV1290;
 }
 
-class art::TModuleDecoderV1290  : public TModuleDecoder {
+class art::TModuleDecoderV1290 : public TModuleDecoder
+{
 public:
    static const int kID = 25;
 
    TModuleDecoderV1290();         // constructor with default id = kID for compatibility
    TModuleDecoderV1290(Int_t id); // constructor with id
    virtual ~TModuleDecoderV1290();
-   virtual Int_t Decode(char* buffer, const int &size, TObjArray *seg);
+   virtual Int_t Decode(char *buffer, const int &size, TObjArray *seg);
 
-   static const unsigned int kHeaderMask        = 0xf8000000;
-   static const unsigned int kGlobalHeader      = 0x40000000;
-   static const unsigned int kTDCHeader         = 0x08000000;
-   static const unsigned int kTDCMeasurement    = 0x00000000;
-   static const unsigned int kTDCTrailer        = 0x18000000;
-   static const unsigned int kTDCError          = 0x20000000;
-   static const unsigned int kGlobalTrailer     = 0x80000000;
-   static const unsigned int kMaskGeometry      = 0x0000001f;
-   static const unsigned int kMaskEventCounter  = 0x7ffffe0;
-   static const unsigned int kMaskBunchID       = 0x00000fff;
-   static const unsigned int kMaskEventID       = 0x00000fff;
-   static const unsigned int kMaskChannel       = 0x03e00000;
-   static const unsigned int kMaskMeasure       = 0x001fffff;
-   static const unsigned int kMaskEdgeType      = 0x04000000;
-   static const int kShiftGeometry     = 0;
+   static const unsigned int kHeaderMask = 0xf8000000;
+   static const unsigned int kGlobalHeader = 0x40000000;
+   static const unsigned int kTDCHeader = 0x08000000;
+   static const unsigned int kTDCMeasurement = 0x00000000;
+   static const unsigned int kTDCTrailer = 0x18000000;
+   static const unsigned int kTDCError = 0x20000000;
+   static const unsigned int kGlobalTrailer = 0x80000000;
+   static const unsigned int kMaskGeometry = 0x0000001f;
+   static const unsigned int kMaskEventCounter = 0x7ffffe0;
+   static const unsigned int kMaskBunchID = 0x00000fff;
+   static const unsigned int kMaskEventID = 0x00000fff;
+   static const unsigned int kMaskChannel = 0x03e00000;
+   static const unsigned int kMaskMeasure = 0x001fffff;
+   static const unsigned int kMaskEdgeType = 0x04000000;
+   static const int kShiftGeometry = 0;
    static const int kShiftEventCounter = 5;
-   static const int kShiftBunchID      = 0;
-   static const int kShiftEventID      = 12;
-   static const int kShiftChannel      = 21;
-   static const int kShiftMeasure      = 0;
-   static const int kShiftEdgeType     = 26;
+   static const int kShiftBunchID = 0;
+   static const int kShiftEventID = 12;
+   static const int kShiftChannel = 21;
+   static const int kShiftMeasure = 0;
+   static const int kShiftEdgeType = 26;
+
+   // Error flags:
+   // [0]: Hit lost in group 0 from read-out FIFO overflow.
+   // [1]: Hit lost in group 0 from L1 buffer overflow
+   // [2]: Hit error have been detected in group 0.
+   // [3]: Hit lost in group 1 from read-out FIFO overflow.
+   // [4]: Hit lost in group 1 from L1 buffer overflow
+   // [5]: Hit error have been detected in group 1.
+   // [6]: Hit data lost in group 2 from read-out FIFO overflow.
+   // [7]: Hit lost in group 2 from L1 buffer overflow
+   // [8]: Hit error have been detected in group 2.
+   // [9]: Hit lost in group 3 from read-out FIFO overflow.
+   // [10]: Hit lost in group 3 from L1 buffer overflow
+   // [11]: Hit error have been detected in group 3.
+   // [12]: Hits rejected because of programmed event size limit
+   // [13]: Event lost (trigger FIFO overflow).
+   // [14]: Internal fatal chip error has been detected
+   static const unsigned int kTDCErrorsSkip = 0b111100100100100;
 
 protected:
    TObjArray *fHitData; // array to temporally store the data for the aggregation
 
-   ClassDef(TModuleDecoderV1290,0); // decoder for module V1290
+   /**
+    * @brief Returns true if the TDC error type is fatal (The segment should be skipped)
+    *
+    * @param evtdata eventdata[i]
+    * @return Bool_t Skip flag
+    */
+   Bool_t TdcErrorCheck(UInt_t evtdata)
+   {
+      if (evtdata && kTDCErrorsSkip)
+         return true;
+      else
+         return false;
+   }
+
+   ClassDef(TModuleDecoderV1290, 0); // decoder for module V1290
 };
 #endif // end of #ifdef TMODULEDECODERV1290_H


### PR DESCRIPTION
Fixes
- Modification for the issue #47
Added `kTDCErrorsSkip = 0b111100100100100` to the `TModuleDecoderV1190` and `TModuleDecoderV1290`
**https://github.com/rin-yokoyama/artemis/blob/6d697564a490c83feed2f06b0de8a50066f080e1/sources/loop/decoder/TModuleDecoderV1190.h#L69**
If one of the error bits with 1 in `kTDCErrorsSkip` is detected, it stops reading the segment. Otherwise, it ignores the TDCError and keep reading the rest of the eventdata.

- added `set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-as-needed")` to `CMakeLists.txt`
In some environment (Ubuntu 22.04.03, GCC11.3.0), shared libraries was not lined to the main artemis exec file due to the linker flag --as-needed by default.